### PR TITLE
feat: integrate login, signup, and activate account api

### DIFF
--- a/common/api/auth.api.ts
+++ b/common/api/auth.api.ts
@@ -13,7 +13,7 @@ export const AuthApi = {
     return auth.post('/register', { ...details });
   },
 
-  verifyAccount(email: string, activationPin: number) {
-    return auth.post('/activate', { email, activationPin })
+  verifyAccount(email: string, otp: number) {
+    return auth.post('/activate', { email, otp })
   }
 }

--- a/common/api/index.ts
+++ b/common/api/index.ts
@@ -21,7 +21,11 @@ export const getAuthHeaders = () => {
   }
 }
 
-export const createAxiosInstance = (baseURL: string) => {
+export const API_BASE = 'https://uzu-dev.herokuapp.com/v1/api';
+
+export const createAxiosInstance = (base: string) => {
+  const baseURL = base.startsWith('http') ? base : `${API_BASE}${base}`;
+
   return axios.create({
     baseURL,
     headers: {

--- a/common/models/interfaces.ts
+++ b/common/models/interfaces.ts
@@ -7,9 +7,15 @@ export interface AsyncResponse {
 }
 
 export interface User {
+  id: string
+  email: string
   firstName: string
   lastName: string
-  middleName: string
-  email: string
+  middleName?: string
   phone: string
+  flagged: boolean
+  activated: boolean
+  token?: string
 }
+
+export type RegisterUserPayload = Partial<User> & { password: string };

--- a/common/storeHelpers/index.ts
+++ b/common/storeHelpers/index.ts
@@ -1,0 +1,22 @@
+import { User } from "../models/interfaces";
+
+
+export interface AppState {
+  currentUser: AuthUser | null
+}
+
+export class AuthUser implements User {
+  id = '';
+  email = '';
+  firstName = '';
+  lastName = '';
+  middleName = '';
+  phone = ''
+  activated = false;
+  flagged = false;
+  token = '';
+}
+
+export enum StoreMutations {
+  setUser = 'setUser'
+}

--- a/components/input-field.vue
+++ b/components/input-field.vue
@@ -21,6 +21,7 @@ export default class InputField extends Vue{
 
   onInputChange(){
     this.$emit('change', this.value);
+    this.$emit('update:value', this.value);
   }
 
 }
@@ -32,7 +33,7 @@ export default class InputField extends Vue{
       <label class="main-input ">
        <span class="secondary-label"> </span>
 
-       <input v-model="value" :type="type ? type : 'text'" @change="onInputChange"/>
+       <input v-model="value" :type="type ? type : 'text'" @keyup="onInputChange"/>
        <span :class="isEmpty ? 'primary-label' : 'primary-label active'"> {{ label }}</span>
       </label>
 

--- a/components/primary-button.vue
+++ b/components/primary-button.vue
@@ -19,6 +19,10 @@ export default class PrimaryButton extends Vue {
   }
 
   handleClick(){
+    if(this.loading){
+      return;
+    }
+    
     this.goToLink();
     this.emitClick();
   }

--- a/layouts/dashboard.vue
+++ b/layouts/dashboard.vue
@@ -19,7 +19,9 @@
 <script lang="ts">
   import { Component, Vue } from 'vue-property-decorator';
 
-  @Component
+  @Component({
+    middleware: ['authenticated']
+  })
   export default class DashboardLayout extends Vue {
     
   }

--- a/layouts/public.vue
+++ b/layouts/public.vue
@@ -1,7 +1,9 @@
 <template>
   <div>
     <navbar />
-    <nuxt />
+    <section class="content-wrapper">
+      <nuxt />
+    </section>
     <main-footer />
   </div>
 </template>
@@ -14,4 +16,7 @@ export default class extends Vue {}
 </script>
 
 <style scoped>
+.content-wrapper{
+  min-height: 70vh;
+}
 </style>

--- a/middleware/authenticated.ts
+++ b/middleware/authenticated.ts
@@ -1,15 +1,18 @@
+import { AppState, StoreMutations } from "~/common/storeHelpers"
 
 
 export default function ({ store, redirect }: any) {
-  const { authUser } = store.state.auth
+  const { currentUser } = store.state as AppState;
   const authUserInSession = sessionStorage.getItem('auth')
 
-  // if (authUserInSession) {
-  //   const data = JSON.parse(authUserInSession)
-  //   store.commit(MUTATIONS.auth.saveAuthData, data)
-  // }
+  if (authUserInSession) {
+    const data = JSON.parse(authUserInSession)
+    store.commit(StoreMutations.setUser, data)
+  }
 
-  // if (!authUser && !authUserInSession) {
-  //   return redirect('/login')
-  // }
+  console.log({ authUserInSession, currentUser })
+
+  if (!currentUser?.token && !authUserInSession) {
+    return redirect('/login')
+  }
 }

--- a/pages/activate-account.vue
+++ b/pages/activate-account.vue
@@ -1,0 +1,92 @@
+<template>
+  <div class="mx-auto mt-12 w-9/11 md:w-1/3" v-if="email">
+    <div class="text-center font-semibold text-xl">Activate Account</div>
+
+    <div class="text-gray-600 mb-2 mt-2">
+      Hi, we've sent an activation pin to your email <span class="text-green-500 font-semibold">{{email}}</span>. 
+      Please enter the 6 digit pin here to continue.
+    </div>
+
+     <input v-model="pin" class="block border border-green-400 p-3 w-full rounded outline-none focus:outline-none" type="text" maxlength="6">
+
+     <div class="mt-8">
+       <primary-button @click="submitActivationPin" :loading="isLoading" label="Continue"></primary-button>
+     </div>
+
+
+     <div class="mt-10">
+       Not <span class="text-green-500 font-semibold">{{email}}</span>, click <button class="font-semibold" @click="allowUserSignup">here</button> to signup.
+     </div>
+  </div>
+</template>
+
+<script lang="ts">
+  import { message } from 'ant-design-vue';
+import { Component, Vue } from 'vue-property-decorator';
+import { AuthApi } from '~/common/api/auth.api';
+import { StoreMutations } from '~/common/storeHelpers';
+import { catchAsync } from '~/common/utilities';
+
+  @Component({
+    layout: 'public',
+  })
+  export default class ActivateAccountPage extends Vue {
+    isLoading = false;
+    email = '';
+    pin = '';
+
+    mounted() {
+      const userEmail = localStorage.getItem('userToActivate');
+
+      if(!userEmail){
+        return this.$router.push('/register');
+      }
+
+      this.email = userEmail;
+    }
+
+    allowUserSignup(){
+      localStorage.removeItem('userToActivate');
+      this.$router.push('/register');
+    }
+
+    async submitActivationPin(){
+      if(!this.pin.length){
+        return;
+      }
+
+      const email = this.email.trim();
+      const activationPin = parseInt(this.pin.trim());
+
+      if(isNaN(activationPin)){
+        this.pin = '';
+        return message.error('Activation Pin is invalid');
+      }
+
+      this.isLoading = true;
+      const { error, data } = await catchAsync(() => AuthApi.verifyAccount(email, activationPin))
+      this.isLoading = false;
+
+      if(error){
+        return message.error(error as string);
+      }
+
+      this.$store.commit(StoreMutations.setUser, data.data);
+
+      message.success('Account activated successfully');
+
+      localStorage.removeItem('userToActivate');
+      this.$router.push('/dashboard');
+    }
+  }
+</script>
+
+<style scoped>
+input{
+  border: 1px solid green;
+  margin: 2em 0;
+  font-size: 2em;
+  letter-spacing: 1em;
+  text-align: center;
+}
+</style>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -42,6 +42,10 @@
 
 <script lang="ts">
   import { Component, Vue } from 'vue-property-decorator';
+  import { message } from 'ant-design-vue';
+  import { catchAsync } from '~/common/utilities';
+  import { AuthApi } from '~/common/api/auth.api';
+  import { AppState, StoreMutations } from '~/common/storeHelpers'
 
 
   @Component
@@ -50,32 +54,48 @@
     password = '';
     loading = false;
 
+    mounted() {
+      const { currentUser } = this.$store as any as AppState;
+      console.log({ currentUser });
+    }
+
     handleEmailChange(value: string){
       this.email = value;
     }
 
     handlePasswordChange(value: string){
-      this.email = value;
+      this.password = value;
     }
     
-    login(){
-      const payload = {
-        email: this.email,
-        password: this.password
-      }
-
-      console.log(payload);
-      this.loading = true;
-
-      setTimeout(() => {
-        this.$router.push('/dashboard');
-      }, 2000);
+    async login(){
       // validate input
       // show loading spinner
       // make api call
       // show success message
       // onSuccess => save token to localstorage
       // redirect to dashboard
+
+      const payload = {
+        email: this.email,
+        password: this.password
+      }
+
+      if(!payload.email.length || !payload.password.length){
+        return message.warning('Please enter a valid email and password')
+      }
+
+      this.loading = true;
+      const { error, data } = await catchAsync(() => AuthApi.login(payload.email, payload.password));
+      this.loading = false;
+
+      if(error){
+        return message.error(error as string);
+      }
+
+      this.$store.commit(StoreMutations.setUser, data.data);
+      this.$router.push('/dashboard');
+
+      message.success('Login successful');
     }
   }
 </script>

--- a/store/index.ts
+++ b/store/index.ts
@@ -1,0 +1,21 @@
+import { AppState, AuthUser, StoreMutations } from "~/common/storeHelpers"
+
+export const state = () => ({
+  currentUser: new AuthUser
+})
+
+export const mutations = {
+  [StoreMutations.setUser](state: AppState, authUser: AuthUser | null) {
+    state.currentUser = authUser;
+  }
+}
+
+export const getters = {
+  currentUser(state: AppState) {
+    return state.currentUser
+  },
+
+  isLoggedIn({ currentUser }: AppState) {
+    return currentUser?.token ? true : false;
+  }
+}


### PR DESCRIPTION

# What changes have been made

1. Add Activate account page
2. Integrate Login Api
3. Integrate Signup api
4. Setup Vuex Store (Auth)

## Screenshots
<img width="700" alt="Screenshot 2021-12-29 at 09 02 52" src="https://user-images.githubusercontent.com/51380881/147640417-b5c38814-a555-44cd-ae71-d46d30e7bb9f.png">

## Other notes
@binadiegha @Afej Please use real emails or a disposable email from https://temp-mail.org/en/ to receive otp and emails.

Cheers fam.